### PR TITLE
README: various improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,45 +3,47 @@
 
 # Jest Standard Reporter
 
-Jest reporter that uses `stdout` for messages and `stderr` for errors
+[Jest](https://jestjs.io/) [reporter](https://jestjs.io/docs/en/configuration#reporters-array-modulename-modulename-options)
+that uses `stdout` for messages and `stderr` for errors.
 
 ## Installation
 
+Using [npm](https://www.npmjs.com/):
+```sh
+npm install --save-dev jest-standard-reporter
 ```
-npm i -D jest-standard-reporter
-yarn add -D jest-standard-reporter
+
+Using [yarn](https://yarnpkg.com/):
+```sh
+yarn add --dev jest-standard-reporter
 ```
 
 ## Usage
 
 Jest CLI:
-
+```sh
+jest --reporters=jest-standard-reporter
 ```
-jest --reporters jest-standard-reporter
-```
 
-Jest Config:
-
-```
+Jest config:
+```json
 {
-    "reporters": ["jest-standard-reporter"],
+    "reporters": ["jest-standard-reporter"]
 }
 ```
 
-Supports the following Jest configurations
+Supports the following Jest configurations:
 
-| Option    | Supported | Info                                    |
-| --------- | --------- | --------------------------------------- |
-| useStderr | ✅        | https://jestjs.io/docs/en/cli#usestderr |
-| verbose   | ✅        | https://jestjs.io/docs/en/cli#verbose   |
+- [`useStderr`](https://jestjs.io/docs/en/cli#usestderr)
+- [`verbose`](https://jestjs.io/docs/en/cli#verbose)
 
 ## Inspiration
 
-Jest uses `stderr` to print the results of the tests (as opposed to `stdout` [see issue #5064](https://github.com/facebook/jest/issues/5064)), many CI tools mark any output coming from `stderr` as a failure making builds to fail even when the tests pass (false positive).
+Jest uses `stderr` to print the results of the tests (as opposed to `stdout`; [see issue #5064](https://github.com/facebook/jest/issues/5064)). Many CI tools mark any output coming from `stderr` as a failure, making builds to fail even when the tests pass (false positive).
 
-This reporter uses `stdout` to print messages an only uses `stderr` when an error is thrown.
+This reporter uses `stdout` to print messages and only uses `stderr` when an error is thrown.
 
-If you chose to, you could override this behavior using `useStderr` flag.
+If you chose to, you could override this behavior using the `useStderr` flag.
 
 ## License
 


### PR DESCRIPTION
Thanks for this, it was exactly what I was looking for!

I made a few small changes to the README, which hopefully improve it a bit:
- Add links for context
- Split npm vs. yarn installation instructions
- Capitalization and punctuation fixes
- Spell out command line options, tor clarity
- Convert table into simpler list

Let me know if any of these changes is unwelcome and I'll remove them from the PR.