### PR TITLE
Use correct binding for this.stdlib

### DIFF
--- a/src/jestStandardReporter.js
+++ b/src/jestStandardReporter.js
@@ -75,7 +75,7 @@ class StandardReporter {
         testResult.snapshot,
         didUpdate
       );
-      snapshotStatuses.forEach(this.stdlib.log);
+      snapshotStatuses.forEach(this.stdlib.log.bind(this.stdlib);
     }
     this.stdlib.forceFlushBufferedOutput();
   }


### PR DESCRIPTION
We need to bind the stdlib correctly or it will throw an error during logging.