### PR TITLE
Update printDisplayName to work with displayName objects

### DIFF
--- a/src/utils/printDisplayName.js
+++ b/src/utils/printDisplayName.js
@@ -4,9 +4,11 @@ const printDisplayName = config => {
   const { displayName } = config;
 
   if (displayName) {
+    const nameToUse = typeof displayName.name === 'string' ? displayName.name : displayName;
+
     return chalk.supportsColor
-      ? chalk.reset.inverse.white(` ${displayName} `)
-      : displayName;
+      ? chalk.reset.inverse.white(` ${nameToUse} `)
+      : nameToUse;
   }
 
   return '';


### PR DESCRIPTION
We are using the Jest projects feature and the displayName configuration is always provided as an object even if we only specify it as a string in our `jest.config.js` file.

When displaying the results with jest-standard-reporter, we are seeing `[object Object]` printed out instead of our provided displayName.

I don't know a lot more about this problem other than I tried this solution for us and it worked well. Let me know if I'm doing something wrong or if there need to be changes. I'm open to making any changes necessary to merge this. Thanks!

## Expected output
![image](https://user-images.githubusercontent.com/20227290/89656905-43aa0300-d89a-11ea-91f1-5d1bd84fe030.png)

## Actual output
![image](https://user-images.githubusercontent.com/20227290/89657158-9e435f00-d89a-11ea-8f2a-bd9437baf491.png)

